### PR TITLE
Feature/singer decimal

### DIFF
--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -56,54 +56,58 @@ LOGGER = singer.get_logger()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+# Define data types
+# Desired types
+#CHAR
+#INTEGER
+#TIMESTMP
+#VARCHAR
+#XML
+
+# Full list
+#BIGINT - int
+#BLOB - xx
+#CHAR - string
+#CLOB - xx
+#DATE - date
+#DECIMAL - float
+#DISTINCT - xx
+#DOUBLE - float
+#INTEGER - int
+#REAL - int
+#SMALLINT - int
+#TIMESTMP - date
+#VARCHAR - string
+#XML - string
+
 STRING_TYPES = set(
     [
-        "binary",
-        "char",
-        "enum",
-        "longtext",
-        "mediumtext",
-        "nchar",
-        "nvarchar",
-        "text",
-        "uniqueidentifier",
-        "varbinary",
-        "varchar",
+        "CHAR",
+        "VARCHAR",
+        "XML",
     ]
 )
 
 BYTES_FOR_INTEGER_TYPE = {
-    "tinyint": 1,
-    "smallint": 2,
-    "mediumint": 3,
-    "int": 4,
-    "integer": 4,
-    "real": 4,
-    "bigint": 8,
+    "SMALLINT": 2,
+    "INTEGER": 4,
+    "REAL": 4
+    "BIGINT": 8,
 }
 
 FLOAT_TYPES = set(
     [
-        "decfloat",
-        "double",
-        "float",
-        "money",
+        "DECIMAL",
+        "DOUBLE",
     ]
 )
 
 DATETIME_TYPES = set(
     [
-        "date",
-        "datetime",
-        "datetime2",
-        "smalldatetime",
-        "time",
-        "timestamp",
+        "DATE",
+        "TIMESTMP",
     ]
 )
-
-VARIANT_TYPES = set(["json"])
-
 
 def schema_for_column(c):
     """Returns the Schema object for the given Column."""
@@ -184,7 +188,7 @@ def discover_catalog(mssql_conn, config):
         tables_results = open_conn.execute(
             """
             SELECT
-                TABSCHEMA AS TABLE_SCHEMA,
+                RTRIM(TABSCHEMA) AS TABLE_SCHEMA,
                 TABNAME AS TABLE_NAME,
                 TYPE AS TABLE_TYPE
             FROM SYSCAT.TABLES t
@@ -214,7 +218,7 @@ def discover_catalog(mssql_conn, config):
         column_results = open_conn.execute(
             """
             SELECT
-                t.TABSCHEMA AS TABLE_SCHEMA,
+                RTRIM(t.TABSCHEMA) AS TABLE_SCHEMA,
                 t.TABNAME AS TABLE_NAME,
                 s.NAME AS COLUMN_NAME,
                 s.COLTYPE AS DATA_TYPE,

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -163,7 +163,7 @@ def schema_for_column(c,config):
 
     elif data_type in FLOAT_TYPE_EXPONENT:
         if use_singer_decimal:
-            result.type = ["null","string"]
+            result.type = ["null","number"]
             result.format = "singer.decimal"
         else:
             result.type = ["null", "number"]
@@ -174,7 +174,7 @@ def schema_for_column(c,config):
 
     elif data_type in DECIMAL_TYPES:
         if use_singer_decimal:
-            result.type = ["null","string"]
+            result.type = ["null","number"]
             result.format = "singer.decimal"
         else:
             result.type = ["null", "number"]

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -209,7 +209,10 @@ def discover_catalog(mssql_conn, config):
                 "is_view": table_type == "V",
             }
 
-            LOGGER.debug(table_info)
+            LOGGER.debug(f"Schema: {db}, Table: {table}")
+            # Previously this would dump the entire catalog each loop
+            # this will only dump the current table info
+            LOGGER.debug(table_info[db][table])
         LOGGER.info("Tables fetched, fetching columns")
         column_results = open_conn.execute(
             """
@@ -230,7 +233,8 @@ def discover_catalog(mssql_conn, config):
             SYSCAT.COLUMNS c
             ON c.TABNAME = t.TABNAME 
             AND c.TABSCHEMA = t.TABSCHEMA 
-            WHERE t.TABSCHEMA NOT LIKE 'SYS%';
+            WHERE t.TABSCHEMA NOT LIKE 'SYS%'
+            ORDER BY t.TABSCHEMA,t.TABNAME,c.COLNO;
             """
         )
         columns = []

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -113,9 +113,13 @@ DATETIME_TYPES = set(
     ]
 )
 
-DATE_TYPES = set(
-        [
+DATE_TYPES = set([
             "date",
+        ]
+)
+
+TIME_TYPES = set([
+            "time",
         ]
 )
 
@@ -208,7 +212,14 @@ def schema_for_column(c,config):
             result.format = "date"
         else:
             result.format = "date-time"
-
+            
+    elif data_type in TIME_TYPES:
+        result.type = ["null", "string"]
+        if use_date_data_type_format:
+            result.format = "time"
+        else:
+            result.format = "date-time"
+            
     else:
         result = Schema(
             None,

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -107,6 +107,13 @@ DATE_TYPES = set(
 def default_date_format():
     return False
 
+def default_offset_value():
+    """
+    Function included to remain consistent with MSSQL tap using a False-returning function
+    for default_date_format
+    """
+    return False
+
 def schema_for_column(c,config):
     """Returns the Schema object for the given Column."""
     data_type = c.data_type.strip().lower()

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -38,7 +38,6 @@ Column = collections.namedtuple(
         "column_name",
         "data_type",
         "character_maximum_length",
-        "numeric_precision",
         "numeric_scale",
         "is_primary_key",
     ],
@@ -57,32 +56,24 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # Define data types
-# Desired types
-#CHAR
-#INTEGER
-#TIMESTMP
-#VARCHAR
-#XML
 
 # Full list
-#BIGINT - int
-#BLOB - xx
-#CHAR - string
-#CLOB - xx
-#DATE - date
-#DECIMAL - float
-#DISTINCT - xx
-#DOUBLE - float
-#INTEGER - int
-#REAL - int
-#SMALLINT - int
-#TIMESTMP - date
-#VARCHAR - string
-#XML - string
+#BIGINT - i
+#BLOB - ignore for now
+#CHARACTER - s
+#CLOB - ignore for now
+#DATE - d
+#DECIMAL - f
+#DOUBLE - f
+#INTEGER - i
+#SMALLINT - i
+#TIMESTAMP - d
+#VARCHAR - s
+#XML - s
 
 STRING_TYPES = set(
     [
-        "char",
+        "character",
         "varchar",
         "xml",
     ]
@@ -91,7 +82,6 @@ STRING_TYPES = set(
 BYTES_FOR_INTEGER_TYPE = {
     "smallint": 2,
     "integer": 4,
-    "real": 4,
     "bigint": 8,
 }
 
@@ -105,7 +95,7 @@ FLOAT_TYPES = set(
 DATETIME_TYPES = set(
     [
         "date",
-        "timestmp",
+        "timestamp",
     ]
 )
 
@@ -217,19 +207,21 @@ def discover_catalog(mssql_conn, config):
             SELECT
                 RTRIM(t.TABSCHEMA) AS TABLE_SCHEMA,
                 t.TABNAME AS TABLE_NAME,
-                s.NAME AS COLUMN_NAME,
-                s.COLTYPE AS DATA_TYPE,
-                s.LENGTH AS CHARACTER_MAXIMUM_LENGTH,
-                s.LONGLENGTH AS NUMERIC_PRECISION,
-                s.SCALE AS NUMERIC_SCALE,
+                c.COLNAME AS COLUMN_NAME,
+                c.TYPENAME AS DATA_TYPE,
+                c.LENGTH AS CHARACTER_MAXIMUM_LENGTH,
+                c."SCALE" AS NUMERIC_SCALE,
                 CASE
-                    WHEN s.KEYSEQ IS NOT NULL THEN 1
+                    WHEN c.KEYSEQ IS NOT NULL THEN 1
                     ELSE 0
                 END AS IS_PRIMARY_KEY
-            FROM SYSIBM.SYSCOLUMNS s
-            LEFT JOIN SYSCAT.TABLES t
-            ON s.TBNAME = t.TABNAME
-            WHERE t.TABSCHEMA NOT LIKE 'SYS%'
+            FROM 
+            SYSCAT.TABLES t
+            LEFT JOIN 
+            SYSCAT.COLUMNS c
+            ON c.TABNAME = t.TABNAME 
+            AND c.TABSCHEMA = t.TABSCHEMA 
+            WHERE t.TABSCHEMA NOT LIKE 'SYS%';
             """
         )
         columns = []

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -200,7 +200,7 @@ def discover_catalog(mssql_conn, config):
                 "is_view": table_type == "V",
             }
 
-            LOGGER.info(table_info)
+            LOGGER.debug(table_info)
         LOGGER.info("Tables fetched, fetching columns")
         column_results = open_conn.execute(
             """

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -155,7 +155,10 @@ def schema_for_column(c,config):
     # all decimals, floats and numerics to number/singer.decimal
     # number with no c.numeric_scale to integer
 
-    if data_type in BYTES_FOR_INTEGER_TYPE:
+    if data_type in ["boolean","bit"]:
+        result.type = ["null","boolean"]
+
+    elif data_type in BYTES_FOR_INTEGER_TYPE:
         result.type = ["null", "integer"]
         bits = BYTES_FOR_INTEGER_TYPE[data_type] * 8
         result.minimum = 0 - 2 ** (bits - 1)

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -146,9 +146,6 @@ def schema_for_column(c):
         result.type = ["null", "string"]
         result.format = "date-time"
 
-    elif data_type in VARIANT_TYPES:
-        result.type = ["null", "object"]
-
     else:
         result = Schema(
             None,

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -91,7 +91,7 @@ STRING_TYPES = set(
 BYTES_FOR_INTEGER_TYPE = {
     "SMALLINT": 2,
     "INTEGER": 4,
-    "REAL": 4
+    "REAL": 4,
     "BIGINT": 8,
 }
 

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -82,30 +82,30 @@ logger.setLevel(logging.INFO)
 
 STRING_TYPES = set(
     [
-        "CHAR",
-        "VARCHAR",
-        "XML",
+        "char",
+        "varchar",
+        "xml",
     ]
 )
 
 BYTES_FOR_INTEGER_TYPE = {
-    "SMALLINT": 2,
-    "INTEGER": 4,
-    "REAL": 4,
-    "BIGINT": 8,
+    "smallint": 2,
+    "integer": 4,
+    "real": 4,
+    "bigint": 8,
 }
 
 FLOAT_TYPES = set(
     [
-        "DECIMAL",
-        "DOUBLE",
+        "decimal",
+        "double",
     ]
 )
 
 DATETIME_TYPES = set(
     [
-        "DATE",
-        "TIMESTMP",
+        "date",
+        "timestmp",
     ]
 )
 

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -26,7 +26,7 @@ import tap_db2.sync_strategies.logical as logical
 
 from tap_db2.connection import (
     # connect_with_backoff,
-    get_azure_sql_engine,
+    get_db2_sql_engine,
 )
 
 
@@ -181,6 +181,7 @@ def discover_catalog(mssql_conn, config):
 
     with mssql_conn.connect() as open_conn:
         LOGGER.info("Fetching tables")
+        # Query for LUW DB2 instances only - SYSCAT may not exist on Z/OS
         tables_results = open_conn.execute(
             """
             SELECT
@@ -213,7 +214,10 @@ def discover_catalog(mssql_conn, config):
             # Previously this would dump the entire catalog each loop
             # this will only dump the current table info
             LOGGER.debug(table_info[db][table])
+            
         LOGGER.info("Tables fetched, fetching columns")
+
+        # Query for LUW DB2 instances only - SYSCAT may not exist on Z/OS
         column_results = open_conn.execute(
             """
             SELECT
@@ -747,7 +751,7 @@ def log_server_params(mssql_conn):
 
 def main_impl():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
-    mssql_conn = get_azure_sql_engine(args.config)
+    mssql_conn = get_db2_sql_engine(args.config)
     log_server_params(mssql_conn)
 
     if args.discover:

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -163,7 +163,7 @@ def schema_for_column(c,config):
 
     elif data_type in FLOAT_TYPE_EXPONENT:
         if use_singer_decimal:
-            result.type = ["null","number"]
+            result.type = ["null","string"]
             result.format = "singer.decimal"
         else:
             result.type = ["null", "number"]

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -152,7 +152,7 @@ def schema_for_column(c,config):
     
     # the tap-oracle behaviour:
     # integer (small/big/normal) to integer - sysmaxsize can hold all these
-    # all decimals, floats and numerics to string/singer.decimal
+    # all decimals, floats and numerics to number/singer.decimal
     # number with no c.numeric_scale to integer
 
     if data_type in BYTES_FOR_INTEGER_TYPE:
@@ -176,6 +176,7 @@ def schema_for_column(c,config):
         if use_singer_decimal:
             result.type = ["null","number"]
             result.format = "singer.decimal"
+            result.additionalProperties = {"scale_precision": f"({c.character_maximum_length},{c.numeric_scale})"}
         else:
             result.type = ["null", "number"]
             # Numeric scale is directly determined by the numeric_scale value

--- a/tap_db2/connection.py
+++ b/tap_db2/connection.py
@@ -57,8 +57,8 @@ def revert_ouput_converter(conn, prev_converter):
     conn.connection.add_output_converter(pyodbc.SQL_WVARCHAR, prev_converter)
 
 
-def get_azure_sql_engine(config) -> Engine:
-    """The All-Purpose SQL connection object for the Azure Data Warehouse."""
+def get_db2_sql_engine(config) -> Engine:
+    """Using parameters from the config to connect to DB2 using ibm_db_sa+pyodbc"""
 
     # connection_string = "ibm_db_sa+pyodbc://db2inst1:*
     # @localhost:50000/TESTDB"

--- a/tap_db2/sync_strategies/common.py
+++ b/tap_db2/sync_strategies/common.py
@@ -103,6 +103,13 @@ def generate_select_sql(catalog_entry, columns):
 def default_date_format():
     return False
 
+def default_offset_value():
+    """
+    Function included to remain consistent with MSSQL tap using a False-returning function
+    for default_date_format
+    """
+    return False
+
 def row_to_singer_record(
     catalog_entry, version, table_stream, row, columns, time_extracted, config
 ):
@@ -193,6 +200,7 @@ def sync_query(
     if len(params) == 0:
         results = cursor.execute(select_sql)
     else:
+        LOGGER.info(params["replication_key_value"])
         results = cursor.execute(select_sql, params["replication_key_value"])
     row = results.fetchone()
     rows_saved = 0

--- a/tap_db2/sync_strategies/common.py
+++ b/tap_db2/sync_strategies/common.py
@@ -158,7 +158,7 @@ def row_to_singer_record(
         elif isinstance(elem, uuid.UUID):
             row_to_persist += (str(elem),)
         
-        elif ('string' in property_type or property_type == 'string') and property_format == 'singer.decimal':
+        elif property_format == 'singer.decimal':
             row_to_persist += (str(elem),)
             
         else:

--- a/tap_db2/sync_strategies/full_table.py
+++ b/tap_db2/sync_strategies/full_table.py
@@ -80,6 +80,7 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
             stream_version,
             table_stream,
             params,
+            config,
         )
 
         if catalog_entry.tap_stream_id == "dbo-InputMetadata":

--- a/tap_db2/sync_strategies/full_table.py
+++ b/tap_db2/sync_strategies/full_table.py
@@ -9,7 +9,7 @@ import tap_db2.sync_strategies.common as common
 
 from tap_db2.connection import (
     connect_with_backoff,
-    get_azure_sql_engine,
+    get_db2_sql_engine,
     modify_ouput_converter,
     revert_ouput_converter,
 )
@@ -35,7 +35,7 @@ def generate_bookmark_keys(catalog_entry):
 
 
 def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version):
-    mssql_conn = get_azure_sql_engine(config)
+    mssql_conn = get_db2_sql_engine(config)
     common.whitelist_bookmark_keys(
         generate_bookmark_keys(catalog_entry), catalog_entry.tap_stream_id, state
     )

--- a/tap_db2/sync_strategies/incremental.py
+++ b/tap_db2/sync_strategies/incremental.py
@@ -91,4 +91,5 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns):
             stream_version,
             table_stream,
             params,
+            config,
         )

--- a/tap_db2/sync_strategies/incremental.py
+++ b/tap_db2/sync_strategies/incremental.py
@@ -5,10 +5,6 @@ import pendulum
 import singer
 from singer import metadata
 
-# from tap_db2.connection import (
-#     # connect_with_backoff,
-#     get_azure_sql_engine,
-# )
 import tap_db2.sync_strategies.common as common
 
 LOGGER = singer.get_logger()

--- a/tap_db2/sync_strategies/incremental.py
+++ b/tap_db2/sync_strategies/incremental.py
@@ -72,11 +72,15 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns):
             
             select_sql += f' WHERE "{replication_key_metadata}" >= ? '
 
+            # Handle the offset value
+            # datetime - use pendulum to alter the value to be passed as a bind parameter
+            # other (numeric) - add the offset value in the SQL
             if replication_key_format == "date-time":
                 replication_key_value = pendulum.parse(replication_key_value).add(seconds=offset_value)
-                select_sql += f' ORDER BY "{replication_key_metadata}" ASC'
             else:
-                select_sql += f' + ({offset_value}) ORDER BY "{replication_key_metadata}" ASC' 
+                select_sql += f' + ({offset_value})' 
+
+            select_sql += f' ORDER BY "{replication_key_metadata}" ASC'
 
             params["replication_key_value"] = replication_key_value
             

--- a/tap_db2/sync_strategies/logical.py
+++ b/tap_db2/sync_strategies/logical.py
@@ -9,7 +9,7 @@ import time
 
 from tap_db2.connection import (
     connect_with_backoff,
-    get_azure_sql_engine,
+    get_db2_sql_engine,
     modify_ouput_converter,
     revert_ouput_converter,
 )

--- a/tests/run_sql.py
+++ b/tests/run_sql.py
@@ -1,0 +1,21 @@
+import tap_db2
+import utils
+import singer
+
+sql_query = """
+select *
+from npfdwhts.mj_test_table;
+"""
+
+# Pick up the required arguments using the singer module
+args = singer.utils.parse_args(tap_db2.REQUIRED_CONFIG_KEYS)
+# Use the connection args from above to connect to your DB2 instance
+db2_conn = utils.get_db2_sql_engine(args.config)
+
+with db2_conn.connect() as open_conn:
+	sql_res = open_conn.execute(sql_query)
+	rec = sql_res.fetchone()
+	print(rec)
+	while rec is not None:
+		rec = sql_res.fetchone()
+		print(rec)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,12 +1,11 @@
 import os
-import pymysql
 import singer
-import tap_mysql
-import tap_mysql.sync_strategies.common as common
-from tap_mysql.connection import MySQLConnection
+import tap_db2
+import tap_db2.sync_strategies.common as common
+from tap_db2.connection import get_db2_sql_engine
 
-DB_NAME = "tap_mysql_test"
-
+def display_config():
+    print(args)
 
 def get_db_config():
     config = {}
@@ -22,25 +21,10 @@ def get_db_config():
 
 
 def get_test_connection():
+    """
+    Connects to DB2 and returns the connection object
+    """
     db_config = get_db_config()
-
-    con = pymysql.connect(**db_config)
-
-    try:
-        with con.cursor() as cur:
-            try:
-                cur.execute("DROP DATABASE {}".format(DB_NAME))
-            except:
-                pass
-            cur.execute("CREATE DATABASE {}".format(DB_NAME))
-    finally:
-        con.close()
-
-    db_config["database"] = DB_NAME
-    db_config["autocommit"] = True
-
-    mysql_conn = MySQLConnection(db_config)
-    mysql_conn.autocommit_mode = True
 
     return mysql_conn
 


### PR DESCRIPTION
Incorporates changes to remove references to other RDBMS types left in when code was copied over from MSSQL and MySQL taps.

Sets up tap-oracle "like" functionality to write large numbers into the singer MESSAGE records as strings, allowing for large/precise numbers to keep precision until handled by the target