### PR TITLE
Feature/oth db2 instances

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name="tap-db2",
     version="1.0.1",
     description="Tap for extracting data from an IBM DB2 database",
-    author="Mark Johnston",
+    author="Mark Johnston, Tom Sloman",
     url="TO-DO",
     classifiers=[
         # "License :: OSI Approved :: GNU Affero General Public License v3",

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ from setuptools import setup
 
 setup(
     name="tap-db2",
-    version="1.0.0",
+    version="1.0.1",
     description="Tap for extracting data from an IBM DB2 database",
-    author="Tom Sloman",
+    author="Mark Johnston",
     url="TO-DO",
     classifiers=[
         # "License :: OSI Approved :: GNU Affero General Public License v3",


### PR DESCRIPTION
Update to initial diagnostic query returning instance information - can now run using `table(sysproc.env_get_inst_info)` instead of `SYSIBMADM.ENV_INST_INFO`. The former requires lower permissions in some instances