### PR TITLE
Fix singer decimal nulls NOT to string

### DIFF
--- a/tap_db2/sync_strategies/common.py
+++ b/tap_db2/sync_strategies/common.py
@@ -161,7 +161,10 @@ def row_to_singer_record(
             row_to_persist += (str(elem),)
         
         elif property_format == 'singer.decimal':
-            row_to_persist += (str(elem),)
+            if elem is None:
+                row_to_persist += (elem,)
+            else:
+                row_to_persist += (str(elem),)
             
         else:
             row_to_persist += (elem,)


### PR DESCRIPTION
Fix which only sets `singer.decimal` values to strings if they are not null. This prevents errors caused by the `RECORD` messages containing `"None"` instead of `null`