### PR TITLE
Preparing for testing using GitHub actions and db2 image

### DIFF
--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -318,7 +318,7 @@ def discover_catalog(db2_conn, config):
             SYSCAT.TABLES t
             LEFT JOIN 
             SYSCAT.COLUMNS c
-            ON c.TABNAME = t.TABNAME 
+            ON (c.TABNAME = t.TABNAME or C.TABNAME = t.BASE_TABNAME) 
             AND c.TABSCHEMA = t.TABSCHEMA 
             WHERE t.TABSCHEMA NOT LIKE 'SYS%'
             ORDER BY t.TABSCHEMA,t.TABNAME,c.COLNO;

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -301,6 +301,7 @@ def discover_catalog(db2_conn, config):
         LOGGER.info("Tables fetched, fetching columns")
 
         # Query for LUW DB2 instances only - SYSCAT may not exist on Z/OS
+        # 1.0.4 - updated to include BASE_TABNAME check for aliases
         column_results = open_conn.execute(
             """
             SELECT

--- a/tap_db2/connection.py
+++ b/tap_db2/connection.py
@@ -60,7 +60,7 @@ def get_db2_sql_engine(config) -> Engine:
 
     # connection_string = "ibm_db_sa+pyodbc://db2inst1:*
     # @localhost:50000/TESTDB"
-    connection_string = "ibm_db_sa+pyodbc://{}:{}@{}:{}/{}".format(
+    connection_string = "ibm_db_sa://{}:{}@{}:{}/{}".format(
         config["username"],
         config["password"],
         config["hostname"],


### PR DESCRIPTION
To prep for testing using the db2 image, the following modifications have been made:

- Switch to ibm_db_sa without pyodbc - removes requirement to preinstall unixodbc and set up DSNs
- Changes to discover code to account for aliases (previously the existence of aliases broke the discover query because they were present in `SYSCAT.TABLES` but not present in `SYSCAT.COLUMNS` when joining using `TABNAME`, needed to use `BASE_TABNAME` to pick up aliases)