### PR TITLE
Add capability to ingest BLOB binary fields

### DIFF
--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -68,7 +68,7 @@ if 'LOGGING_CONF_FILE' in os.environ and os.environ['LOGGING_CONF_FILE']:
 
 # Full list
 #BIGINT - i
-#BLOB - ignore for now
+#BLOB - binary
 #CHARACTER - s
 #CLOB - ignore for now
 #DATE - d
@@ -79,6 +79,12 @@ if 'LOGGING_CONF_FILE' in os.environ and os.environ['LOGGING_CONF_FILE']:
 #TIMESTAMP - d
 #VARCHAR - s
 #XML - s
+
+BINARY_TYPES = set(
+    [
+        "blob",
+    ]
+)
 
 STRING_TYPES = set(
     [
@@ -228,6 +234,10 @@ def schema_for_column(c,config):
             result.format = "time"
         else:
             result.format = "date-time"
+
+    elif data_type in BINARY_TYPES:
+        result.type = ["null", "string"]
+        result.maxLength = c.character_maximum_length
             
     else:
         result = Schema(
@@ -836,3 +846,7 @@ def main():
     except Exception as exc:
         LOGGER.critical(exc)
         raise exc
+
+if __name__ == '__main__':
+    LOGGER.info('here')
+    main()  # pylint: disable=no-value-for-parameter

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -846,7 +846,3 @@ def main():
     except Exception as exc:
         LOGGER.critical(exc)
         raise exc
-
-if __name__ == '__main__':
-    LOGGER.info('here')
-    main()  # pylint: disable=no-value-for-parameter

--- a/tap_db2/sync_strategies/common.py
+++ b/tap_db2/sync_strategies/common.py
@@ -6,6 +6,7 @@ import datetime
 import singer
 import time
 import uuid
+import base64
 
 import singer.metrics as metrics
 from singer import metadata
@@ -140,11 +141,22 @@ def row_to_singer_record(
             timedelta_from_epoch = epoch + elem
             row_to_persist += (timedelta_from_epoch.isoformat() + "+00:00",)
 
-        elif isinstance(elem, bytes):
+        elif isinstance(elem, (bytes, bytearray, memoryview)):
+            
+            
             if sql_data_type in ["binary", "varbinary"]:
-                # Convert binary byte array to hex string‘
+                # Convert binary to hex string
                 hex_representation = f"0x{elem.hex().upper()}"
                 row_to_persist += (hex_representation,)
+            elif sql_data_type == "blob":
+                # Ensure it is converted to bytes so .hex() is available
+                byte_val = elem.tobytes() if isinstance(elem, memoryview) else elem
+                try:
+                    # This makes it "readable" text again
+                    row_to_persist += (byte_val.decode("utf-8"),)
+                except UnicodeDecodeError:
+                    # Fallback to Hex or Base64 if it's actually binary data
+                    row_to_persist += (f"0x{byte_val.hex().upper()}",)
             else:
                 # for BIT value, treat 0 as False and anything else as True
                 boolean_representation = elem != b"\x00"

--- a/tap_db2/sync_strategies/common.py
+++ b/tap_db2/sync_strategies/common.py
@@ -6,6 +6,7 @@ import datetime
 import singer
 import time
 import uuid
+import base64
 
 import singer.metrics as metrics
 from singer import metadata
@@ -151,8 +152,8 @@ def row_to_singer_record(
                 # Ensure it is converted to bytes so .hex() is available
                 byte_val = elem.tobytes() if isinstance(elem, memoryview) else elem
                 try:
-                    # This makes it "readable" text again
-                    row_to_persist += (byte_val.decode("utf-8"),)
+                    # Convert to Base64 encoded string
+                    row_to_persist += (base64.b64encode(byte_val),)
                 except UnicodeDecodeError:
                     # Fallback to Hex or Base64 if it's actually binary data
                     row_to_persist += (f"0x{byte_val.hex().upper()}",)

--- a/tap_db2/sync_strategies/common.py
+++ b/tap_db2/sync_strategies/common.py
@@ -6,7 +6,6 @@ import datetime
 import singer
 import time
 import uuid
-import base64
 
 import singer.metrics as metrics
 from singer import metadata


### PR DESCRIPTION
Uses Base64 encoding to encode BLOB binary data into a JSON-serializable string. This can then be decoded once landed in Snowflake.